### PR TITLE
fix(azure): added unique suffix to Azure resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ resource "random_id" "uniq" {
 
 module "az_al_ad_application" {
   source                      = "lacework/ad-application/azure"
-  version                     = "0.1.0"
+  version                     = "~> 0.1"
   create                      = var.use_existing_ad_application ? false : true
   application_name            = var.application_name
   application_identifier_uris = var.application_identifier_uris

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,10 @@ locals {
   service_principal_id = var.use_existing_ad_application ? var.service_principal_id : module.az_al_ad_application.service_principal_id
 }
 
+resource "random_id" "uniq" {
+  byte_length = 4
+}
+
 module "az_al_ad_application" {
   source                      = "lacework/ad-application/azure"
   version                     = "0.1.0"
@@ -18,14 +22,14 @@ module "az_al_ad_application" {
 }
 
 resource "azurerm_resource_group" "lacework" {
-  name     = "${var.prefix}-group"
+  name     = "${var.prefix}-group-${random_id.uniq.hex}"
   location = var.location
 }
 
 # NOTE: storage name can only consist of lowercase letters and numbers,
 # and must be between 3 and 24 characters long
 resource "azurerm_storage_account" "lacework" {
-  name                      = "${var.prefix}storage"
+  name                      = substr("${var.prefix}storage${random_id.uniq.hex}", 0, 24)
   account_kind              = "StorageV2"
   account_tier              = "Standard"
   account_replication_type  = "LRS"
@@ -36,12 +40,12 @@ resource "azurerm_storage_account" "lacework" {
 }
 
 resource "azurerm_storage_queue" "lacework" {
-  name                 = "${var.prefix}-queue"
+  name                 = "${var.prefix}-queue-${random_id.uniq.hex}"
   storage_account_name = azurerm_storage_account.lacework.name
 }
 
 resource "azurerm_eventgrid_event_subscription" "lacework" {
-  name  = "${var.prefix}-subscription"
+  name  = "${var.prefix}-subscription-${random_id.uniq.hex}"
   scope = azurerm_storage_account.lacework.id
 
   storage_queue_endpoint {
@@ -59,7 +63,7 @@ resource "azurerm_eventgrid_event_subscription" "lacework" {
 }
 
 resource "azurerm_monitor_log_profile" "lacework" {
-  name               = "${var.prefix}-log-profile"
+  name               = "${var.prefix}-log-profile-${random_id.uniq.hex}"
   locations          = var.log_profile_locations
   storage_account_id = azurerm_storage_account.lacework.id
 
@@ -79,7 +83,7 @@ resource "azurerm_monitor_log_profile" "lacework" {
 # TODO @afiune maybe we could add a subscription_id variable
 data "azurerm_subscription" "primary" {}
 resource "azurerm_role_definition" "lacework" {
-  name        = "${var.prefix}-role"
+  name        = "${var.prefix}-role-${random_id.uniq.hex}"
   description = "Used by Lacework to monitor Activity Logs"
   scope       = data.azurerm_subscription.primary.id
 

--- a/variables.tf
+++ b/variables.tf
@@ -4,12 +4,12 @@ variable "location" {
   default     = "West US 2"
 }
 
-# NOTE: this prefix is used in all resources and we have a limitatino with the
+# NOTE: this prefix is used in all resources and we have a limitation with the
 # storage name that can only consist of lowercase letters and numbers, and must
 # be between 3 and 24 characters long
 variable "prefix" {
   type        = string
-  default     = "l4c3w0rk"
+  default     = "lacework"
   description = "The prefix that will be use at the beginning of every generated resource"
 }
 
@@ -23,9 +23,7 @@ variable "application_name" {
 variable "application_identifier_uris" {
   type        = list(string)
   description = "A list of user-defined URI(s) for the Lacework AD Application"
-  default = [
-    "https://securityaudit.lacework.net"
-  ]
+  default     = []
 }
 
 variable "subscription_ids" {


### PR DESCRIPTION
- Added unique suffix to Azure resources
- Updated 'azurerm_role_definition.lacework.id' to 'azurerm_role_definition.lacework.role_definition_resource_id'  (https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment#example-usage-custom-role--service-principal)
- Changed default prefix from 'l4c3w0rk' to 'lacework'