### PR TITLE
ci: switch releases to be own by Lacework releng ⚡

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       - checkout
       - add_ssh_keys:
           fingerprints:
-            - "04:ea:9d:e5:99:37:e5:c9:0e:23:e1:46:6d:a8:e2:38"
+            - "1f:ab:a5:38:bc:dc:e5:b8:c9:63:6f:c9:47:ca:9f:62"
       - run: scripts/release.sh trigger
   release:
     executor: alpine

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -10,8 +10,8 @@ set -eou pipefail
 
 readonly org_name=lacework
 readonly project_name=terraform-azure-activity-log
-readonly git_user="Salim Afiune Maya"
-readonly git_email="afiune@lacework.net"
+readonly git_user="Lacework Inc."
+readonly git_email="ops+releng@lacework.net"
 VERSION=$(cat VERSION)
 
 usage() {


### PR DESCRIPTION
As a Lacework Engineer, 
I would like to use an in-house Github account to set up all releases and pipelines
So I don't have to use my personal Github account.

## Description
We are starting to use the company's Github account https://github.com/lacework-releng to do
our automated releases.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>