### PR TITLE
chore: bump required TF version and fix pessimistic version pinning on minor releases of dependent modules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ resource "random_id" "uniq" {
 
 module "az_al_ad_application" {
   source                      = "lacework/ad-application/azure"
-  version                     = "~> 0.1.0"
+  version                     = "~> 0.1"
   create                      = var.use_existing_ad_application ? false : true
   application_name            = var.application_name
   application_identifier_uris = var.application_identifier_uris

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.12.31"
 
   required_providers {
     azuread = ">= 0.11"

--- a/versions.tf
+++ b/versions.tf
@@ -7,7 +7,7 @@ terraform {
     random  = ">= 2.1"
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.2.0"
+      version = "~> 0.3"
     }
   }
 }


### PR DESCRIPTION
This PR bumps the required version of Terraform to 0.12.31 to address HCSEC-2021-12 and fixes pessimistic version pinning on minor releases of dependent modules

Signed-off-by: Scott Ford <scott.ford@lacework.net>