### PR TITLE
fix: azurerm_role_assignment definition id

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -125,7 +125,7 @@ resource "azurerm_role_definition" "lacework" {
 }
 
 resource "azurerm_role_assignment" "lacework" {
-  role_definition_id = azurerm_role_definition.lacework.id
+  role_definition_id = azurerm_role_definition.lacework.role_definition_resource_id
   principal_id       = local.service_principal_id
   scope              = data.azurerm_subscription.primary.id
 }


### PR DESCRIPTION
Azure has some issues internally where they had to expose a new
attribute to reference a role definition, we are fixing this issue by
using it as per comment at:

https://github.com/terraform-providers/terraform-provider-azurerm/issues/8618

>If you want to use the azure id to do role assignment, please refer to this doc https://www.terraform.io/docs/providers/azurerm/r/role_assignment.html and use role_definition_resource_id. For example:


Signed-off-by: Salim Afiune Maya <afiune@lacework.net>