### PR TITLE
Limit App permission to Storage Queue endpoint

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -95,37 +95,12 @@ resource "azurerm_monitor_log_profile" "lacework" {
   }
 }
 
-# TODO @afiune maybe we could add a subscription_id variable
-data "azurerm_subscription" "primary" {}
-resource "azurerm_role_definition" "lacework" {
-  name        = "${var.prefix}-role-${random_id.uniq.hex}"
-  description = "Used by Lacework to monitor Activity Logs"
-  scope       = data.azurerm_subscription.primary.id
-
-  assignable_scopes = [
-    data.azurerm_subscription.primary.id
-  ]
-
-  permissions {
-    actions = [
-      "Microsoft.Resources/subscriptions/resourceGroups/read",
-      "Microsoft.Storage/storageAccounts/read",
-      "Microsoft.Storage/storageAccounts/blobServices/containers/read",
-      "Microsoft.Storage/storageAccounts/queueServices/queues/read",
-      "Microsoft.EventGrid/eventSubscriptions/read",
-      "Microsoft.Storage/storageAccounts/listkeys/action"
-    ]
-
-    data_actions = [
-      "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read",
-      "Microsoft.Storage/storageAccounts/queueServices/queues/messages/read",
-      "Microsoft.Storage/storageAccounts/queueServices/queues/messages/delete"
-    ]
-  }
+data "azurerm_role_definition" "queue_processor" {
+  name = "Storage Queue Data Message Processor"
 }
 
 resource "azurerm_role_assignment" "lacework" {
-  role_definition_id = azurerm_role_definition.lacework.role_definition_resource_id
+  role_definition_id = data.azurerm_role_definition.queue_processor.id
   principal_id       = local.service_principal_id
   scope              = azurerm_storage_account.lacework.id
 }

--- a/main.tf
+++ b/main.tf
@@ -100,7 +100,7 @@ data "azurerm_role_definition" "queue_processor" {
 }
 
 resource "azurerm_role_assignment" "lacework" {
-  role_definition_id = data.azurerm_role_definition.queue_processor.id
+  role_definition_id = data.azurerm_role_definition.queue_processor.role_definition_id
   principal_id       = local.service_principal_id
   scope              = local.storage_account_id
 }

--- a/main.tf
+++ b/main.tf
@@ -102,7 +102,7 @@ data "azurerm_role_definition" "queue_processor" {
 resource "azurerm_role_assignment" "lacework" {
   role_definition_id = data.azurerm_role_definition.queue_processor.id
   principal_id       = local.service_principal_id
-  scope              = azurerm_storage_account.lacework.id
+  scope              = local.storage_account_id
 }
 
 # wait for X seconds for the Azure resources to be created

--- a/main.tf
+++ b/main.tf
@@ -127,7 +127,7 @@ resource "azurerm_role_definition" "lacework" {
 resource "azurerm_role_assignment" "lacework" {
   role_definition_id = azurerm_role_definition.lacework.role_definition_resource_id
   principal_id       = local.service_principal_id
-  scope              = data.azurerm_subscription.primary.id
+  scope              = azurerm_storage_account.lacework.id
 }
 
 # wait for X seconds for the Azure resources to be created


### PR DESCRIPTION
It is enough to use builtin RBAC role to access Queue endpoint.
It is enough to scope the role to the Storage Account.