### PR TITLE
fix: use data source when using existing storage account

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -83,10 +83,15 @@ resource "azurerm_eventgrid_event_subscription" "lacework" {
 }
 
 resource "azurerm_monitor_log_profile" "lacework" {
-  count              = var.use_existing_log_profile ? 0 : 1
-  name               = local.log_profile_name
-  locations          = var.log_profile_locations
-  storage_account_id = azurerm_storage_account.lacework[0].id
+  count     = var.use_existing_log_profile ? 0 : 1
+  name      = local.log_profile_name
+  locations = var.log_profile_locations
+
+  storage_account_id = var.use_existing_storage_account ? (
+    data.azurerm_storage_account.lacework[0].id
+    ) : (
+    azurerm_storage_account.lacework[0].id
+  )
 
   categories = [
     "Action",


### PR DESCRIPTION
***Issue***: N/A

***Description:***
When the user sets the input `use_existing_storage_account = true` we
need to use the data source rather than the resource.

Users report the following error:
```
╷
│ Error: Invalid index
│
│   on .terraform/modules/az_activity_log/main.tf line 89, in resource “azurerm_monitor_log_profile” “lacework”:
│   89:   storage_account_id = azurerm_storage_account.lacework[0].id
│     ├────────────────
│     │ azurerm_storage_account.lacework is empty tuple
│
│ The given key does not identify an element in this collection value: the collection has no elements.
```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>
