### PR TITLE
fix: pull only enabled subscriptions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   subscription_ids = var.all_subscriptions ? (
     // the user wants to grant access to all subscriptions
-    [for s in data.azurerm_subscriptions.available.subscriptions : s.subscription_id]
+    [for s in data.azurerm_subscriptions.available.subscriptions : s.subscription_id if s.state == "Enabled"]
     ) : (
     // or, if the user wants to grant a list of subscriptions,
     // if none then we default to the primary subscription


### PR DESCRIPTION
## Summary

Attempting to modify a disabled subscription results in a 409, we should only pull enabled subscriptions if a user enabled the all_subscriptions flag

## How did you test this change?

Performed a terraform apply using my fork, ensured that we are still pulling the expected subscriptions

This functionality is also being changed in -> https://github.com/lacework/terraform-azure-config/pull/35