### PR TITLE
Upgrade the azurerm provider to 3.x

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.14"
 
   required_providers {
-    azurerm = "~> 2.28"
+    azurerm = "~> 3.7"
     random  = ">= 2.1"
     lacework = {
       source  = "lacework/lacework"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-azure-activity-log/blob/main/CONTRIBUTING.md
--->

## Summary

azurerm 2.x is deprecated and the module prevent the use of azurerm 3.x where it's being used.

Sibling to https://github.com/lacework/terraform-azure-config/pull/38