### PR TITLE
docs: update Lacework provider version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It configures a Diagnostic Setting that puts logs in an storage account, from wh
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 2.28 |
-| <a name="requirement_lacework"></a> [lacework](#requirement\_lacework) | ~> 0.3 |
+| <a name="requirement_lacework"></a> [lacework](#requirement\_lacework) | ~> 1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.1 |
 
 ## Providers
@@ -22,7 +22,7 @@ It configures a Diagnostic Setting that puts logs in an storage account, from wh
 | Name | Version |
 |------|---------|
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 2.28 |
-| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | ~> 0.3 |
+| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | ~> 1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.1 |
 | <a name="provider_time"></a> [time](#provider\_time) | n/a |
 


### PR DESCRIPTION
set version of terraform-provider-lacework to 1.0.0 in readme

[_Created by Sourcegraph batch change `darren.murray/terraform-readme`._](https://lacework.sourcegraph.com/users/darren.murray/batch-changes/terraform-readme)