### PR TITLE
feat: allow subscription exclusions when `all_subscriptions` is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ It configures a Diagnostic Setting that puts logs in an storage account, from wh
 | <a name="input_service_principal_id"></a> [service\_principal\_id](#input\_service\_principal\_id) | The Enterprise App Object ID related to the application\_id (required when use\_existing\_ad\_application is true) | `string` | `""` | no |
 | <a name="input_storage_account_name"></a> [storage\_account\_name](#input\_storage\_account\_name) | The name of the Storage Account | `string` | `""` | no |
 | <a name="input_storage_account_resource_group"></a> [storage\_account\_resource\_group](#input\_storage\_account\_resource\_group) | The Resource Group for the existing Storage Account | `string` | `""` | no |
+| <a name="input_subscription_exclusions"></a> [subscription\_exclusions](#input\_subscription\_exclusions) | List of subscriptions to exclude when using the `all_subscriptions` option. | `list(string)` | `[]` | no |
 | <a name="input_subscription_ids"></a> [subscription\_ids](#input\_subscription\_ids) | List of subscriptions to enable logging (by default the module will only use the primary subscription) | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Key-value map of Tag names and Tag values | `map(string)` | `{}` | no |
 | <a name="input_use_existing_ad_application"></a> [use\_existing\_ad\_application](#input\_use\_existing\_ad\_application) | Set this to `true` to use an existing Active Directory Application | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   subscription_ids = var.all_subscriptions ? (
     // the user wants to grant access to all subscriptions
-    [for s in data.azurerm_subscriptions.available.subscriptions : s.subscription_id if s.state == "Enabled"]
+    [for s in data.azurerm_subscriptions.available.subscriptions : s.subscription_id if s.state == "Enabled" && !contains(var.subscription_exclusions, s.subscription_id)]
     ) : (
     // or, if the user wants to grant a list of subscriptions,
     // if none then we default to the primary subscription

--- a/variables.tf
+++ b/variables.tf
@@ -56,14 +56,19 @@ variable "storage_account_resource_group" {
   default     = ""
   description = "The Resource Group for the existing Storage Account"
 }
+variable "subscription_exclusions" {
+  type        = list(string)
+  description = "List of subscriptions to exclude when using the `all_subscriptions` option."
+  default     = []
+}
 variable "subscription_ids" {
   type        = list(string)
   description = "List of subscriptions to enable logging (by default the module will only use the primary subscription)"
   default     = []
 }
 variable "tags" {
-  type = map(string)
-  default = {}
+  type        = map(string)
+  default     = {}
   description = "Key-value map of Tag names and Tag values"
 }
 variable "use_existing_ad_application" {


### PR DESCRIPTION
## Summary

This PR allows for subscription exclusions when a user enabled the `all_subscriptions` boolean.  This should resolve #64 

## How did you test this change?

Verified exclusion logic works by excluding an existing integration.

## Issue

N/A
