### PR TITLE
fix: add dependency to azurerm_monitor_diagnostic_setting resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -183,6 +183,7 @@ resource "time_sleep" "wait_time" {
   depends_on = [
     azurerm_eventgrid_event_subscription.lacework,
     azurerm_storage_queue.lacework,
+    azurerm_monitor_diagnostic_setting.lacework,
     azurerm_role_assignment.lacework
   ]
   triggers = {


### PR DESCRIPTION

## Summary
Users could have a problem with the azurerm_monitor_diagnostic_setting resource and still have the integration show as successful in the Lacework console.

Example error:
```
│  with module.az_activity_log.azurerm_monitor_diagnostic_setting.lacework[6],
│  on .terraform/modules/az_activity_log/main.tf line 94, in resource "azurerm_monitor_diagnostic_setting" "lacework":
│  94: resource "azurerm_monitor_diagnostic_setting" "lacework" {
```

Adding a dependency here will avoid the integration to be created unless the resource succeeds.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>

## Issue

https://lacework.atlassian.net/browse/GROW-1368