### PR TITLE
fix(storage): turn off nested public permission

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -58,6 +58,8 @@ resource "azurerm_storage_account" "lacework" {
   resource_group_name       = azurerm_resource_group.lacework[0].name
   tags                      = azurerm_resource_group.lacework[0].tags
   #enable_blob_encryption    = true
+
+  allow_nested_items_to_be_public = false
 }
 
 resource "azurerm_storage_queue" "lacework" {


### PR DESCRIPTION
## Summary

Since azurerm 3.0+ storage account have a new flag: [allow_nested_items_to_be_public](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account#allow_nested_items_to_be_public)

WIthout this PR, this flag is enabled by default, and I don't see ANY reason for that storage account to have public accessible files - but I might be wrong...
Without this change:
```
  # module.az_activity_log.azurerm_storage_account.lacework[0] will be updated in-place
  ~ resource "azurerm_storage_account" "lacework" {
      ~ allow_nested_items_to_be_public   = false -> true
        id                                = "/subscriptions/xxxx"
      ~ min_tls_version                   = "TLS1_0" -> "TLS1_2"
        name                              = "laceworkstorageXXXXXXX"
        tags                              = {}
        # (31 unchanged attributes hidden)

        # (4 unchanged blocks hidden)
    }
```

Ref. https://github.com/lacework/terraform-azure-activity-log/issues/73