### PR TITLE
refactor: use `for_each instead of `count`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -103,10 +103,10 @@ resource "azurerm_eventgrid_event_subscription" "lacework" {
 
 # create Diag Settings on all subscriptions requested by user, centralizing logs in single storage
 resource "azurerm_monitor_diagnostic_setting" "lacework" {
-  count = length(local.subscription_ids)
+  for_each = toset(local.subscription_ids)
 
   name               = "${var.prefix}-${var.diagnostic_settings_name}-${random_id.uniq.hex}"
-  target_resource_id = "/subscriptions/${local.subscription_ids[count.index]}"
+  target_resource_id = "/subscriptions/${each.key}"
   storage_account_id = local.storage_account_id
 
   log {


### PR DESCRIPTION
## Summary

We use the `count` operator in the diagnostic settings resource which ultimately translates into
multiple resources with a numeric index like:
```
  # module.az_activity_log.azurerm_monitor_diagnostic_setting.lacework[1] will be created
  # module.az_activity_log.azurerm_monitor_diagnostic_setting.lacework[2] will be created
  # module.az_activity_log.azurerm_monitor_diagnostic_setting.lacework[3] will be created
  # module.az_activity_log.azurerm_monitor_diagnostic_setting.lacework[...] will be created
  # module.az_activity_log.azurerm_monitor_diagnostic_setting.lacework[N] will be created
```

When removing subscription(s) it has been reported that this action triggers a re-indexing which in
turn results in a destroy/create operation for all diagnostic settings resources.

To avoid that, we are replacing the use of `count` in favor of `for_each`, the difference is that, the
translation of the resources will look like this:
```
module.az_activity_log.azurerm_monitor_diagnostic_setting.lacework["00000000-0000-0000-0000-000000000001"] will be created
module.az_activity_log.azurerm_monitor_diagnostic_setting.lacework["00000000-0000-0000-0000-000000000002"] will be created
module.az_activity_log.azurerm_monitor_diagnostic_setting.lacework["00000000-0000-0000-0000-000000000003"] will be created
module.az_activity_log.azurerm_monitor_diagnostic_setting.lacework["00000000-0000-0000-0000-000000000004"] will be created
module.az_activity_log.azurerm_monitor_diagnostic_setting.lacework["00000000-0000-0000-0000-000000000..."] will be created
module.az_activity_log.azurerm_monitor_diagnostic_setting.lacework["00000000-0000-0000-0000-00000000000N"] will be created
```

Which ultimately will avoid the re-indexing and therefore, the destroy/create operation

## How did you test this change?

Running an upgrade to see what customers will experience, created integrations with two subscriptions:
```
module.az_activity_log.azurerm_monitor_diagnostic_setting.lacework[1]: Creating...
module.az_activity_log.azurerm_monitor_diagnostic_setting.lacework[0]: Creating...
module.az_activity_log.azurerm_monitor_diagnostic_setting.lacework[0]: Creation complete after 2s [id=/subscriptions/000000-0000-0000-0000-000000000001|lacework-activity-logs-c24313e9]
module.az_activity_log.azurerm_monitor_diagnostic_setting.lacework[1]: Creation complete after 2s [id=/subscriptions/000000-0000-0000-0000-000000000002|lacework-activity-logs-c24313e9]
```
Upgraded the module with this change and re-ran `terraform apply`:
```
  # module.az_activity_log.azurerm_monitor_diagnostic_setting.lacework[0] will be destroyed
  # module.az_activity_log.azurerm_monitor_diagnostic_setting.lacework[1] will be destroyed
  # module.az_activity_log.azurerm_monitor_diagnostic_setting.lacework["000000-0000-0000-0000-000000000001"] will be created
  # module.az_activity_log.azurerm_monitor_diagnostic_setting.lacework["000000-0000-0000-0000-000000000002"] will be created
```

Essentially, this change will trigger a destroy to all `azurerm_monitor_diagnostic_setting` resources
and recreate them with the new ones using `for_each`.
## Issue

https://lacework.atlassian.net/browse/GROW-1225
