### PR TITLE
fix: Replace deprecated `log` blocks with `enabled_log`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -109,37 +109,20 @@ resource "azurerm_monitor_diagnostic_setting" "lacework" {
   target_resource_id = "/subscriptions/${local.subscription_ids[count.index]}"
   storage_account_id = local.storage_account_id
 
-  log {
+  enabled_log {
     category = "Administrative"
-    enabled  = true
   }
-  log {
+  enabled_log {
     category = "Security"
-    enabled  = true
   }
-  log {
+  enabled_log {
     category = "Alert"
-    enabled  = true
   }
-  log {
+  enabled_log {
     category = "Policy"
-    enabled  = true
   }
-  log {
+  enabled_log {
     category = "ResourceHealth"
-    enabled  = true
-  }
-  log {
-    category = "Autoscale"
-    enabled  = false
-  }
-  log {
-    category = "Recommendation"
-    enabled  = false
-  }
-  log {
-    category = "ServiceHealth"
-    enabled  = false
   }
 
   # Currently required for https://github.com/hashicorp/terraform-provider-azurerm/issues/8131

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.14"
 
   required_providers {
-    azurerm = "~> 3.0"
+    azurerm = "~> 3.71"
     random  = ">= 2.1"
     lacework = {
       source  = "lacework/lacework"


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-azure-activity-log/blob/main/CONTRIBUTING.md
--->

## Summary

The log block in azurerm_monitor_diagnostic_setting is deprecated, but starting from 3.71.0 of azurerm, it's now required to have an enabled_log block.
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

Tested my changes locally, it's a NOOP:
```
No changes. Your infrastructure matches the configuration.
```

## Issue

Fixes #87 
