### PR TITLE
feat(infra-encryption): enable if storage account is created

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ It configures a Diagnostic Setting that puts logs in an storage account, from wh
 | <a name="input_application_name"></a> [application\_name](#input\_application\_name) | The name of the Azure Active Directory Application (required when use\_existing\_ad\_application is set to true) | `string` | `"lacework_security_audit"` | no |
 | <a name="input_application_password"></a> [application\_password](#input\_application\_password) | The Active Directory Application password to use (required when use\_existing\_ad\_application is set to true) | `string` | `""` | no |
 | <a name="input_diagnostic_settings_name"></a> [diagnostic\_settings\_name](#input\_diagnostic\_settings\_name) | The name of the subscription's Diagnostic Setting for Activity Logs | `string` | `"activity-logs"` | no |
+| <a name="input_infrastructure_encryption_enabled"></a> [infrastructure\_encryption\_enabled](#input\_infrastructure\_encryption\_enabled) | Enable Infrastructure Encryption for Azure Storage Account | `bool` | `false` | no |
 | <a name="input_lacework_integration_name"></a> [lacework\_integration\_name](#input\_lacework\_integration\_name) | The Lacework integration name | `string` | `"TF activity log"` | no |
 | <a name="input_location"></a> [location](#input\_location) | Azure region where the storage account for logging will reside | `string` | `"West US 2"` | no |
 | <a name="input_log_retention_days"></a> [log\_retention\_days](#input\_log\_retention\_days) | Specifies the number of days that logs will be retained | `number` | `10` | no |

--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,7 @@ resource "azurerm_storage_account" "lacework" {
   resource_group_name               = azurerm_resource_group.lacework[0].name
   tags                              = azurerm_resource_group.lacework[0].tags
   min_tls_version                   = "TLS1_2"
-  infrastructure_encryption_enabled = true
+  infrastructure_encryption_enabled = var.infrastructure_encryption_enabled
   allow_nested_items_to_be_public   = false
   queue_properties {
     logging {

--- a/main.tf
+++ b/main.tf
@@ -48,18 +48,18 @@ data "azurerm_storage_account" "lacework" {
 }
 
 resource "azurerm_storage_account" "lacework" {
-  count                     = var.use_existing_storage_account ? 0 : 1
-  name                      = local.storage_account_name
-  account_kind              = "StorageV2"
-  account_tier              = "Standard"
-  account_replication_type  = "LRS"
-  enable_https_traffic_only = true
-  location                  = var.location
-  resource_group_name       = azurerm_resource_group.lacework[0].name
-  tags                      = azurerm_resource_group.lacework[0].tags
-  min_tls_version           = "TLS1_2"
-  #enable_blob_encryption    = true
-  allow_nested_items_to_be_public = false
+  count                             = var.use_existing_storage_account ? 0 : 1
+  name                              = local.storage_account_name
+  account_kind                      = "StorageV2"
+  account_tier                      = "Standard"
+  account_replication_type          = "LRS"
+  enable_https_traffic_only         = true
+  location                          = var.location
+  resource_group_name               = azurerm_resource_group.lacework[0].name
+  tags                              = azurerm_resource_group.lacework[0].tags
+  min_tls_version                   = "TLS1_2"
+  infrastructure_encryption_enabled = true
+  allow_nested_items_to_be_public   = false
   queue_properties {
     logging {
       delete                = true

--- a/variables.tf
+++ b/variables.tf
@@ -91,5 +91,10 @@ variable "wait_time" {
   default     = "50s"
   description = "Amount of time to wait before the Lacework resources are provisioned"
 }
+variable "infrastructure_encryption_enabled" {
+  type        = bool
+  default     = false
+  description = "Enable Infrastructure Encryption for Azure Storage Account"
+}
 
 


### PR DESCRIPTION
## Summary

Resolve issue with CIS Microsoft Azure Foundations Benchmark 3.2 control. Ensure that if a storage account is created Infrastructure Encryption has been enabled.

## How did you test this change?

Executed the updated module and validated that the new storage account has `Infrastructure encryption` enabled in the Azure portal.

## Issue

https://lacework.atlassian.net/browse/GROW-2513
