### PR TITLE
fix: ignore resource group tags changes to avoid policy collisions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -70,6 +70,11 @@ resource "azurerm_storage_account" "lacework" {
       retention_policy_days = var.log_retention_days
     }
   }
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "azurerm_storage_account_network_rules" "lacework" {

--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,11 @@ resource "azurerm_resource_group" "lacework" {
   name     = "${var.prefix}-group-${random_id.uniq.hex}"
   location = var.location
   tags     = var.tags
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 # NOTE: storage name can only consist of lowercase letters and numbers,
@@ -69,11 +74,6 @@ resource "azurerm_storage_account" "lacework" {
       version               = "1.0"
       retention_policy_days = var.log_retention_days
     }
-  }
-  lifecycle {
-    ignore_changes = [
-      tags
-    ]
   }
 }
 


### PR DESCRIPTION
## Summary

Tags can be automatically added to storage account by Azure Policy. This PR ignores the tags to avoid unnecessary resource changes.

## How did you test this change?

tf apply
tf plan
tf destroy

## Issue

https://lacework.atlassian.net/browse/GROW-2568
