### PR TITLE
adding ability to reuse existing subnet

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,7 @@ locals {
   version_file   = "${abspath(path.module)}/VERSION"
   module_name    = "terraform-azure-activity-log"
   module_version = fileexists(local.version_file) ? file(local.version_file) : ""
+  existing_subnet_id = var.use_existing_subnet ? var.existing_subnet_id : azurerm_subnet.lacework[0].id
 }
 
 module "az_ad_application" {
@@ -94,7 +95,7 @@ resource "azurerm_storage_account_network_rules" "lacework" {
   ip_rules           = concat(var.storage_account_network_rule_ip_rules,
   var.storage_account_network_rule_lacework_ip_rules)
 
-  virtual_network_subnet_ids = [azurerm_subnet.lacework.id]
+  virtual_network_subnet_ids = [local.existing_subnet_id]
 
   depends_on = [azurerm_storage_queue.lacework]
 }
@@ -235,6 +236,7 @@ data "lacework_metric_module" "lwmetrics" {
 
 # virtual network and subnet
 resource "azurerm_virtual_network" "lacework" {
+  count               = var.use_existing_subnet ? 0 : 1
   name                = "lacework-vnet"
   address_space       = ["10.0.0.0/16"]
   location            = local.storage_account_resource_group_location
@@ -242,9 +244,10 @@ resource "azurerm_virtual_network" "lacework" {
 }
 
 resource "azurerm_subnet" "lacework" {
+  count               = var.use_existing_subnet ? 0 : 1
   name                 = "lacework-subnet"
   resource_group_name  = local.storage_account_resource_group_name
-  virtual_network_name = azurerm_virtual_network.lacework.name
+  virtual_network_name = azurerm_virtual_network.lacework[0].name
   address_prefixes     = ["10.0.1.0/24"]
   service_endpoints    = ["Microsoft.Storage"]
 
@@ -255,7 +258,7 @@ resource "azurerm_private_endpoint" "lacework" {
   name                = "lacework-private-endpoint"
   location            = local.storage_account_resource_group_location
   resource_group_name = local.storage_account_resource_group_name
-  subnet_id           = azurerm_subnet.lacework.id
+  subnet_id           = local.existing_subnet_id
 
   private_service_connection {
     name                           = "lacework-privateserviceconnection"

--- a/variables.tf
+++ b/variables.tf
@@ -23,6 +23,11 @@ variable "diagnostic_settings_name" {
   default     = "activity-logs"
   description = "The name of the subscription's Diagnostic Setting for Activity Logs (required when use_existing_diagnostic_settings is set to true)"
 }
+variable "existing_subnet_id" {
+  type        = string
+  default     = ""
+  description = "Subnet ID for existing VNet to use for creating the private endpoint and/or storage account access rules"
+}
 variable "use_existing_diagnostic_settings" {
   type        = bool
   default     = false
@@ -91,6 +96,12 @@ variable "use_existing_storage_account" {
   default     = false
   description = "Set this to `true` to use an existing Storage Account. Default behavior creates a new Storage Account"
 }
+variable "use_existing_subnet" {
+  type        = bool
+  default     = false
+  description = "Set this to `true` to use an existing VNet Subnet ID. Default behavior creates a new VNet"
+}
+
 variable "wait_time" {
   type        = string
   default     = "50s"
@@ -153,5 +164,7 @@ variable "storage_account_network_rule_lacework_ip_rules" {
   ]
   description = "List of allowed Lacework ip addresses. See https://docs.lacework.net/onboarding/lacework-outbound-ips#docusaurus_skipToContent_fallback. Requires `use_storage_account_network_rules` enabled."
 }
+
+
 
 


### PR DESCRIPTION
I needed the ability to reuse an existing subnet to be used for the private endpoint and avoid creating a new VNet and subnet just to create the private endpoint. We already have the ability to reuse other existing resources, might as well be able to reuse a subnet as well.
