### PR TITLE
fix(sev-2577): Add subscription_id into examples

### DIFF
--- a/examples/all-subscriptions-in-tenant/main.tf
+++ b/examples/all-subscriptions-in-tenant/main.tf
@@ -1,4 +1,5 @@
 provider "azurerm" {
+  subscription_id = "00000000-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   features {}
 }
 

--- a/examples/custom-activity-log/main.tf
+++ b/examples/custom-activity-log/main.tf
@@ -1,4 +1,5 @@
 provider "azurerm" {
+  subscription_id = "00000000-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   features {}
 }
 

--- a/examples/default-activity-log/main.tf
+++ b/examples/default-activity-log/main.tf
@@ -1,4 +1,5 @@
 provider "azurerm" {
+  subscription_id = "00000000-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   features {}
 }
 

--- a/examples/existing-diagnostic-settings/main.tf
+++ b/examples/existing-diagnostic-settings/main.tf
@@ -1,6 +1,7 @@
 provider "azuread" {}
 
 provider "azurerm" {
+  subscription_id = "00000000-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   features {}
 }
 

--- a/examples/existing-storage-account/main.tf
+++ b/examples/existing-storage-account/main.tf
@@ -1,6 +1,7 @@
 provider "azuread" {}
 
 provider "azurerm" {
+  subscription_id = "00000000-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   features {}
 }
 

--- a/examples/multiple-subscriptions-in-tenant/main.tf
+++ b/examples/multiple-subscriptions-in-tenant/main.tf
@@ -1,4 +1,5 @@
 provider "azurerm" {
+  subscription_id = "00000000-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   features {}
 }
 

--- a/examples/multiple-tenants/main.tf
+++ b/examples/multiple-tenants/main.tf
@@ -3,6 +3,7 @@ provider "lacework" {}
 # Tenant 1
 provider "azurerm" {
   tenant_id = "00000000-0000-0000-0000-000000000001"
+  subscription_id = "00000000-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   alias     = "tenant_1"
   features {}
 }

--- a/examples/storage-account-network-rules/main.tf
+++ b/examples/storage-account-network-rules/main.tf
@@ -1,4 +1,5 @@
 provider "azurerm" {
+  subscription_id = "00000000-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   features {}
 }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-azure-activity-log/blob/main/CONTRIBUTING.md
--->

## Summary

Add subscription_id into examples after upgrade azurerm to 4.0 version

## How did you test this change?

Tested locally by running `terraform plan`

## Issue

<!--
  Include the link to a Jira/Github issue
-->
