### PR TITLE
chore: add subscription_id to examples

### DIFF
--- a/examples/all-subscriptions-in-tenant/README.md
+++ b/examples/all-subscriptions-in-tenant/README.md
@@ -5,6 +5,7 @@ single Azure tenant with Lacework for Activity Log analysis.
 
 ```hcl
 provider "azurerm" {
+  subscription_id = "00000000-0000-0000-0000-000000000001"
   features {}
 }
 

--- a/examples/all-subscriptions-in-tenant/main.tf
+++ b/examples/all-subscriptions-in-tenant/main.tf
@@ -1,4 +1,5 @@
 provider "azurerm" {
+  subscription_id = "00000000-0000-0000-0000-000000000001"
   features {}
 }
 

--- a/examples/custom-activity-log/README.md
+++ b/examples/custom-activity-log/README.md
@@ -7,6 +7,7 @@ for Activity Log analysis. This example customizes the integration using module 
 
 ```hcl
 provider "azurerm" {
+  subscription_id = "00000000-0000-0000-0000-000000000001"
   features {}
 }
 

--- a/examples/custom-activity-log/main.tf
+++ b/examples/custom-activity-log/main.tf
@@ -1,4 +1,5 @@
 provider "azurerm" {
+  subscription_id = "00000000-0000-0000-0000-000000000001"
   features {}
 }
 

--- a/examples/default-activity-log/README.md
+++ b/examples/default-activity-log/README.md
@@ -7,6 +7,7 @@ for Activity Log analysis using default values.
 
 ```hcl
 provider "azurerm" {
+  subscription_id = "00000000-0000-0000-0000-000000000001"
   features {}
 }
 
@@ -23,7 +24,7 @@ For detailed information on integrating Lacework with Azure, see [Azure Complian
 ## Selecting a different Subscription ID
 
 By default, all resources are provisioned to the default subscription of the Azure tenant. You can change
-that behavior by providing the `subscription_id` argument inside the `azurerm` provider, or by setting the 
+that behavior by providing the `subscription_id` argument inside the `azurerm` provider, or by setting the
 `ARM_SUBSCRIPTION_ID` environment variable.
 
 Here is an example of integrating a few subscriptions and selecting a different subscription from the default

--- a/examples/default-activity-log/main.tf
+++ b/examples/default-activity-log/main.tf
@@ -1,4 +1,5 @@
 provider "azurerm" {
+  subscription_id = "00000000-0000-0000-0000-000000000001"
   features {}
 }
 
@@ -6,4 +7,4 @@ provider "lacework" {}
 
 module "az_activity_log" {
   source = "../../"
-} 
+}

--- a/examples/existing-diagnostic-settings/README.md
+++ b/examples/existing-diagnostic-settings/README.md
@@ -5,6 +5,7 @@ for Activity Log analysis using an existing Diagnostic Settings.
 
 ```hcl
 provider "azurerm" {
+  subscription_id = "00000000-0000-0000-0000-000000000001"
   features {}
 }
 

--- a/examples/existing-diagnostic-settings/main.tf
+++ b/examples/existing-diagnostic-settings/main.tf
@@ -1,6 +1,7 @@
 provider "azuread" {}
 
 provider "azurerm" {
+  subscription_id = "00000000-0000-0000-0000-000000000001"
   features {}
 }
 

--- a/examples/existing-storage-account/README.md
+++ b/examples/existing-storage-account/README.md
@@ -5,6 +5,7 @@ for Activity Log analysis using an existing Storage Account.
 
 ```hcl
 provider "azurerm" {
+  subscription_id = "00000000-0000-0000-0000-000000000001"
   features {}
 }
 

--- a/examples/existing-storage-account/main.tf
+++ b/examples/existing-storage-account/main.tf
@@ -1,6 +1,7 @@
 provider "azuread" {}
 
 provider "azurerm" {
+  subscription_id = "00000000-0000-0000-0000-000000000001"
   features {}
 }
 

--- a/examples/multiple-subscriptions-in-tenant/README.md
+++ b/examples/multiple-subscriptions-in-tenant/README.md
@@ -5,6 +5,7 @@ single Azure tenant with Lacework for Activity Log analysis.
 
 ```hcl
 provider "azurerm" {
+  subscription_id = "00000000-0000-0000-0000-000000000001"
   features {}
 }
 

--- a/examples/multiple-subscriptions-in-tenant/main.tf
+++ b/examples/multiple-subscriptions-in-tenant/main.tf
@@ -1,4 +1,5 @@
 provider "azurerm" {
+  subscription_id = "00000000-0000-0000-0000-000000000001"
   features {}
 }
 

--- a/examples/multiple-tenants/README.md
+++ b/examples/multiple-tenants/README.md
@@ -7,6 +7,7 @@ provider "lacework" {}
 
 # Tenant 1
 provider "azurerm" {
+  subscription_id = "00000000-0000-0000-0000-000000000001"
   tenant_id = "00000000-0000-0000-0000-000000000001"
   alias     = "tenant_1"
   features {}
@@ -24,6 +25,7 @@ module "az_activity_log_tenant_1" {
 
 # Tenant 2
 provider "azurerm" {
+  subscription_id = "00000000-0000-0000-0000-000000000002"
   tenant_id = "00000000-0000-0000-0000-000000000002"
   alias     = "tenant_2"
   features {}

--- a/examples/multiple-tenants/main.tf
+++ b/examples/multiple-tenants/main.tf
@@ -2,6 +2,7 @@ provider "lacework" {}
 
 # Tenant 1
 provider "azurerm" {
+  subscription_id = "00000000-0000-0000-0000-000000000001"
   tenant_id = "00000000-0000-0000-0000-000000000001"
   alias     = "tenant_1"
   features {}
@@ -16,6 +17,7 @@ module "az_activity_log_tenant_1" {
 
 # Tenant 2
 provider "azurerm" {
+  subscription_id = "00000000-0000-0000-0000-000000000002"
   tenant_id = "00000000-0000-0000-0000-000000000002"
   alias     = "tenant_2"
   features {}

--- a/examples/storage-account-network-rules/README.md
+++ b/examples/storage-account-network-rules/README.md
@@ -6,6 +6,7 @@ The following example shows configuring storage account network rules. Whenuse_s
 
 ```hcl
 provider "azurerm" {
+  subscription_id = "00000000-0000-0000-0000-000000000001"
   features {}
 }
 

--- a/examples/storage-account-network-rules/main.tf
+++ b/examples/storage-account-network-rules/main.tf
@@ -1,4 +1,5 @@
 provider "azurerm" {
+  subscription_id = "00000000-0000-0000-0000-000000000001"
   features {}
 }
 


### PR DESCRIPTION
## Summary

`subscription_id` is required as of azurerm 4.0

